### PR TITLE
Invoices with created at date

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -10,11 +10,10 @@ class Invoice < ApplicationRecord
   end
 
   def self.not_shipped
-    joins(:invoice_items).where("invoice_items.status = 0 OR invoice_items.status = 1").distinct.order(created_at: :asc)
-  end
-
-  def least_recent
-
+    joins(:invoice_items)
+    .where("invoice_items.status = 0 OR invoice_items.status = 1")
+    .distinct
+    .order(created_at: :asc)
   end
 
   def date_format

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -20,7 +20,9 @@
   <ul>
     <% @items_ready_to_ship.each do |invoice| %>
       <% invoice.invoice_items.each do |invoice_item| %>
-        <li><%= invoice_item.item.name %> - Invoice#<%= link_to "#{invoice_item.invoice.id}", merchant_invoice_path(@merchant, invoice_item.invoice), method: :get %> </li>
+        <li><%= invoice_item.item.name %> - Invoice#<%= link_to "#{invoice_item.invoice.id}", merchant_invoice_path(@merchant, invoice_item.invoice), method: :get %>
+             <%= invoice_item.invoice.date_format %>
+        </li>
       <% end %>
     <% end %>
   </ul>

--- a/spec/features/merchant_dashboard_spec.rb
+++ b/spec/features/merchant_dashboard_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe "Merchant Dashboard" do
     @invoice_5 = @customers.fifth.invoices.first
     @invoice_6 = @customers[5].invoices.first
     @invoice_7 = @customers[6].invoices.first
+
     9.times {create(:transaction, invoice_id: @invoice_1.id, result: 0)}
     8.times {create(:transaction, invoice_id: @invoice_2.id, result: 0)}
     7.times {create(:transaction, invoice_id: @invoice_3.id, result: 0)}
@@ -70,6 +71,16 @@ RSpec.describe "Merchant Dashboard" do
         expect(page).to have_content(@invoice_3.id)
         expect(page).to have_content(@invoice_5.id)
         expect(page).to_not have_content(@invoice_4.id)
+      end
+    end
+
+    it "can display the invoices with the date created at" do
+      visit "/merchant/#{@merchant1.id}/dashboard"
+
+      within "#items-ready-to-ship" do
+        expected = @invoice_1.created_at.strftime('%A, %B %d, %Y')
+
+        expect(page).to have_content(expected)
       end
     end
   end


### PR DESCRIPTION
Added the feature spec to incorporate formatted date created at next to each invoice.
Updated the merchant dashboard index with the functionality to display the formatted date next to each invoice.
Tidied up the invoice model method for not shipped to make it easier to read. Need to figure out how to incorporate in the feature and/or model spec for an invoice the ordering of least recent invoices based on their created at date. 

