### PR TITLE
Fix command rails db:migrate to heroku run rails db:migrate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ workflows:
             branches:
               only: main
           post-steps:
-            - run: rails db:migrate
+            - run: heroku run rails db:migrate
 
 jobs:
   build:


### PR DESCRIPTION
### What's Changed
- Circleci could not auto deploy because the post-steps command needs to be linked to Heroku when running `rails db:migrate` command. So updated the command to run `heroku run rails db:migrate`