### PR TITLE
Add heroku env var to reference app to run post-step command for

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ workflows:
             branches:
               only: main
           post-steps:
-            - run: heroku run rails db:migrate
+            - run: heroku run rails db:migrate -a ENV['HEROKU_APP_NAME']
 
 jobs:
   build:


### PR DESCRIPTION
### What's Changed
- Circleci needed the environment variable for the heroku app in order to know which app to run the post-step db migration command for